### PR TITLE
Changes to work with current version of React Native

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,14 +5,14 @@
 * @flow-weak
 */
 'use strict';
-var React = require('react-native');
+var React = require('react');
 
 var {
     View,
     Image,
     Text,
     StyleSheet,
-} = React;
+} = require('react-native');
 
 
 var md5 = require("./md5.js");

--- a/storageMgr.js
+++ b/storageMgr.js
@@ -4,7 +4,7 @@
 */
 'use strict';
 
-var Sqlite = require('@remobile/react-native-sqlite');
+var Sqlite = require('react-native-sqlite-storage');
 var fs = require('react-native-fs');
 
 const DB_NAME = "cache_image";


### PR DESCRIPTION
React needed to be imported from 'react' rather than 'react-native', otherwise it would cause an error saying React.createClass is undefined.
